### PR TITLE
Allow sync to happen only on revision sha1

### DIFF
--- a/lib/rim/command/sync.rb
+++ b/lib/rim/command/sync.rb
@@ -38,6 +38,9 @@ class Sync < Command
     opts.on("-r", "--target-revision REVISION", String, "Set the target revision of the module.") do |target_revision|
       @module_options[:target_revision] = target_revision
     end
+    opts.on("--revision-sha1 SHA1", String, "Set the target SHA1 of the module.") do |revision_sha1|
+      @module_options[:revision_sha1] = revision_sha1
+    end
     opts.on("-i", "--ignore PATTERN_LIST", String, "Set the ignore patterns by specifying a comma separated list.") do |ignores|
       @module_options[:ignores] = ignores || ""
     end
@@ -70,6 +73,7 @@ class Sync < Command
             @module_options[:remote_url],
             local_path,
             @module_options[:target_revision],
+            @module_options[:revision_sha1],
             @module_options[:ignores],
             @module_options[:subdir],
         ))

--- a/lib/rim/command_helper.rb
+++ b/lib/rim/command_helper.rb
@@ -32,11 +32,12 @@ class CommandHelper < Processor
     raise RimException.new("Unexpected command line arguments.") if !ARGV.empty?
   end
 
-  def create_module_info(remote_url, local_path, target_revision, ignores, subdir)
+  def create_module_info(remote_url, local_path, target_revision, revision_sha1, ignores, subdir)
     ModuleInfo.new(
         remote_url,
         get_relative_path(local_path),
         target_revision,
+        revision_sha1,
         ignores,
         remote_url ? get_remote_branch_format(remote_url) : nil,
         subdir)
@@ -70,6 +71,7 @@ class CommandHelper < Processor
         opts.has_key?(:remote_url) ? opts[:remote_url] : rim_info.remote_url,
         module_path,
         opts.has_key?(:target_revision) ? opts[:target_revision] : rim_info.target_revision,
+        opts.has_key?(:revision_sha1) ? opts[:revision_sha1] : rim_info.revision_sha1,
         opts.has_key?(:ignores) ? opts[:ignores] : rim_info.ignores,
         opts.has_key?(:subdir) ? opts[:subdir] : rim_info.subdir)
       if module_info.valid?

--- a/lib/rim/module_info.rb
+++ b/lib/rim/module_info.rb
@@ -9,6 +9,8 @@ class ModuleInfo
   attr_reader :local_path
   # target revision
   attr_reader :target_revision
+  # revision sha1
+  attr_reader :revision_sha1
   # ignores
   attr_reader :ignores
 
@@ -17,6 +19,7 @@ class ModuleInfo
   def initialize(remote_url,
                  local_path,
                  target_revision,
+                 revision_sha1 = nil,
                  ignores = nil,
                  remote_branch_format = nil,
                  subdir = nil)
@@ -24,6 +27,7 @@ class ModuleInfo
     @remote_branch_format = remote_branch_format
     @local_path = local_path
     @target_revision = target_revision
+    @revision_sha1 = revision_sha1
     @subdir = subdir
     if ignores.is_a?(String)
       @ignores = ignores.split(",").each do |s| 

--- a/lib/rim/sync_module_helper.rb
+++ b/lib/rim/sync_module_helper.rb
@@ -31,6 +31,9 @@ module RIM
           if !s.rev_sha1(@module_info.target_revision)
             raise RimException.new("Unknown target revision '#{@module_info.target_revision}' for module '#{@module_info.local_path}'.")
           end
+          if @module_info.revision_sha1 && !s.rev_sha1(@module_info.revision_sha1)
+            raise RimException.new("Unknown target sha1 '#{@module_info.revision_sha1}' for module '#{@module_info.local_path}'.")
+          end
           local_path = File.join(@dest_root, @module_info.local_path)
           prepare_empty_folder(local_path, @module_info.ignores)
           temp_commit(d, "clear directory") if d.uncommited_changes?
@@ -40,7 +43,11 @@ module RIM
               strip = "--strip-components=#{depth}"
           end
           s.execute("git archive --format tar #{@module_info.target_revision} #{@module_info.subdir} | tar #{strip} -C #{local_path} -xf -")
-          sha1 = s.execute("git rev-parse #{@module_info.target_revision}").strip
+          sha1 = if @module_info.revision_sha1
+            s.execute("git rev-parse #{@module_info.revision_sha1}").strip
+          else
+            s.execute("git rev-parse #{@module_info.target_revision}").strip
+          end
           @rim_info = RimInfo.new
           @rim_info.remote_url = @module_info.remote_url
           @rim_info.target_revision = @module_info.target_revision

--- a/lib/rim/version.rb
+++ b/lib/rim/version.rb
@@ -2,7 +2,7 @@ module RIM
 
 module Version
 
-Version = "1.4.4"
+Version = "1.4.5"
 
 end
 

--- a/test/sync_helper_test.rb
+++ b/test/sync_helper_test.rb
@@ -51,7 +51,7 @@ class SyncHelperTest < Minitest::Test
 
   def test_files_are_synchronized_subtree
     mod_git_dir = create_all_module_git("mod_all")
-    mod_a_info =  RIM::ModuleInfo.new("file://" + mod_git_dir, "modules/a", "master", nil, nil, "mod_a")
+    mod_a_info =  RIM::ModuleInfo.new("file://" + mod_git_dir, "modules/a", "master", nil, nil, nil, "mod_a")
     create_ws_git("testbr")
     cut = RIM::SyncHelper.new(@ws_dir, @logger, [mod_a_info])
     cut.sync
@@ -70,7 +70,7 @@ class SyncHelperTest < Minitest::Test
 
   def test_files_are_synchronized_subtree_deep
     mod_git_dir = create_all_module_git("mod_all")
-    mod_a_info =  RIM::ModuleInfo.new("file://" + mod_git_dir, "modules/b_src", "master", nil, nil, "mod_b/src")
+    mod_a_info =  RIM::ModuleInfo.new("file://" + mod_git_dir, "modules/b_src", "master", nil, nil, nil, "mod_b/src")
     create_ws_git("testbr")
     cut = RIM::SyncHelper.new(@ws_dir, @logger, [mod_a_info])
     cut.sync

--- a/test/sync_module_helper_test.rb
+++ b/test/sync_module_helper_test.rb
@@ -84,7 +84,7 @@ class SyncModuleHelperTest < Minitest::Test
     write_file(File.join(test_folder, "folder"), "file1")
     write_file(File.join(test_folder, "folder"), "file2")
     write_file(File.join(test_folder, "folder2"), "file1")
-    info = RIM::ModuleInfo.new(@remote_git_dir_url, "test", "testbr", "**/file2")
+    info = RIM::ModuleInfo.new(@remote_git_dir_url, "test", "testbr", nil, "**/file2")
     cut = RIM::SyncModuleHelper.new(@ws_dir, @ws_dir, info, @logger)
     cut.sync
     assert File.exists?(File.join(test_folder, "readme.txt"))

--- a/test/upload_helper_test.rb
+++ b/test/upload_helper_test.rb
@@ -81,7 +81,7 @@ class UploadHelperTest < Minitest::Test
 
   def test_files_of_new_commits_are_uploaded_subdir
     mod_git_dir = create_all_module_git("mod_all")
-    mod_a_info =  RIM::ModuleInfo.new("file://" + mod_git_dir, "modules/a", "master", nil, nil, "mod_a")
+    mod_a_info =  RIM::ModuleInfo.new("file://" + mod_git_dir, "modules/a", "master", nil, nil, nil, "mod_a")
     create_ws_git("testbr")
     sync_helper = RIM::SyncHelper.new(@ws_dir, @logger, [mod_a_info])
     sync_helper.sync
@@ -356,7 +356,7 @@ private
       s.execute("git commit -m \"Initial commit\"")
       s.execute("git checkout --detach #{branch}")
     end
-    return RIM::ModuleInfo.new("file://" + git_dir, name, branch, nil, remote_branch_format)
+    return RIM::ModuleInfo.new("file://" + git_dir, name, branch, nil, nil, remote_branch_format)
   end
 
   def create_all_module_git(name, branch = "master")


### PR DESCRIPTION
Add options --revision-sha1 to rim sync, allowing to sync to a certain sha1. The target revision was not good enough as it made the rim module sticky to the target revision