### PR TITLE
rim info: mark invalid current_sha1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -151,3 +151,7 @@
 # 1.4.6
 
 * Fixed issue #28: rim sync is not working in root of destination repository
+
+# 1.4.7
+
+* Added a notification in `rim info` in case the current SHA1 is not an existing commit

--- a/lib/rim/git.rb
+++ b/lib/rim/git.rb
@@ -98,6 +98,13 @@ class GitSession
     end
     nil
   end
+
+  # check whether a commit exists
+  def commit_exists?(sha)
+    execute("git rev-parse --quiet --verify #{sha}^{commit}") do |b, e|
+      return !e
+    end
+  end
   
   # check whether branch exists
   def has_branch?(branch)

--- a/lib/rim/info_helper.rb
+++ b/lib/rim/info_helper.rb
@@ -23,7 +23,11 @@ class InfoHelper < CommandHelper
     @module_helpers.each do |h|
       path = h.module_info.local_path.split(/[\\\/]/).last.ljust(40)
       info = "#{path}: ->#{h.target_rev.ljust(10)} @#{h.current_sha1[0..6]}"
-      if h.upstream_revs
+
+      if (!h.current_commit_exists)
+        info += " [COMMIT NOT FOUND]"
+        @logger.info(info)
+      elsif h.upstream_revs
         if h.upstream_revs.size > 0
           info += " [#{h.upstream_revs.size} commits behind]"
         else

--- a/lib/rim/info_module_helper.rb
+++ b/lib/rim/info_module_helper.rb
@@ -5,6 +5,7 @@ module RIM
 class InfoModuleHelper < ModuleHelper
 
   attr_accessor :target_rev
+  attr_accessor :current_commit_exists
   attr_accessor :current_sha1
   attr_accessor :upstream_revs
   attr_accessor :upstream_non_fast_forward
@@ -19,6 +20,10 @@ class InfoModuleHelper < ModuleHelper
     @target_rev = rim_info.target_revision
     @current_sha1 = rim_info.revision_sha1
     RIM::git_session(git_path) do |s|
+      if s.commit_exists?(current_sha1)
+        @current_commit_exists = true
+      end
+
       if s.has_remote_branch?(target_rev)
         # repository is mirrored so branches are "local"
         if s.is_ancestor?(current_sha1, target_rev)

--- a/lib/rim/version.rb
+++ b/lib/rim/version.rb
@@ -2,7 +2,7 @@ module RIM
 
 module Version
 
-Version = "1.4.6"
+Version = "1.4.7"
 
 end
 


### PR DESCRIPTION
Sometimes the SHA1 of the current commit that rim has synced to no longer exists (e. g. if JOSH is updated and uses new hashes for its virtual commits). This PR makes `rim info` print out a notification when this happens so that this case can be recognized.