### PR TITLE
Added info about which files have been changed.

### DIFF
--- a/lib/rim/command/status.rb
+++ b/lib/rim/command/status.rb
@@ -93,6 +93,11 @@ class Status < Command
       @logger.info headline
       dirty_mods.each do |m|
         @logger.info "        - #{m.dir}"
+        gs.changed_files(stat.git_rev).each do |changed|
+          if changed.path.start_with?(m.dir)
+            @logger.info "           #{changed.kind}: #{changed.path}"
+          end
+        end
       end
     elsif dirty_mods.size > 0
       @logger.info "#{headline} (#{dirty_mods.size} modules dirty)"


### PR DESCRIPTION
If the commit is dirty, but it was changed in a previous commit, will not show any changed files.

This helps a lot when there are unexpected differences between git and local files after sync

Background: When syncing a library with a bigger commit, it would be easier to see what changes has been made straight from esr-rim