### PR TITLE
Update github workflow for verification ruby setup

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
         ruby-version: ['2.7']
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
 


### PR DESCRIPTION
actions/setup-ruby is deprecated and no longer maintained, but ruby/setup-ruby is the actively-maintained replacement, so this commit migrates rim over to use that.