### PR TITLE
[WIP] Change MiniTest namespace to latest

### DIFF
--- a/lib/rim/command_helper.rb
+++ b/lib/rim/command_helper.rb
@@ -35,7 +35,7 @@ class CommandHelper < Processor
   def create_module_info(remote_url, local_path, target_revision, ignores, subdir)
     ModuleInfo.new(
         remote_url,
-        get_relative_path(local_path),
+        FileHelper.get_relative_path(local_path),
         target_revision,
         ignores,
         remote_url ? get_remote_branch_format(remote_url) : nil,

--- a/lib/rim/git.rb
+++ b/lib/rim/git.rb
@@ -33,7 +33,7 @@ class GitSession
 
   def self.open(execute_dir, options = {})
     log = @logger || Logger.new($stdout)
-    self.new(log, execute_dir, options)
+    new(log, execute_dir, options)
   end
 
   def self.next_invocation_id

--- a/lib/rim/processor.rb
+++ b/lib/rim/processor.rb
@@ -50,10 +50,6 @@ def remote_path(remote_url)
     gsub(/\.\.[\\\/]/,'')
 end
 
-def get_relative_path(path)
-  FileHelper.get_relative_path(path, @ws_root)
-end
-
 def get_absolute_remote_url(remote_url)
   if remote_url.start_with?("file:")
     remote_url = remote_url.gsub(/^file:(\/\/)?/, "")

--- a/test/dirty_check_test.rb
+++ b/test/dirty_check_test.rb
@@ -7,7 +7,7 @@ require 'test_helper'
 require 'rim/rim_info'
 require 'rim/dirty_check'
 
-class DirtyCheckTest < MiniTest::Test
+class DirtyCheckTest < Minitest::Test
 
 include FileUtils
 include TestHelper

--- a/test/git_test.rb
+++ b/test/git_test.rb
@@ -6,7 +6,7 @@ require 'fileutils'
 require 'test_helper'
 require 'rim/git'
 
-class GitTest < MiniTest::Test
+class GitTest < Minitest::Test
 
 include FileUtils
 include TestHelper

--- a/test/rim_info_test.rb
+++ b/test/rim_info_test.rb
@@ -6,7 +6,7 @@ require 'fileutils'
 require 'test_helper'
 require 'rim/rim_info'
 
-class RimInfoTest < MiniTest::Test
+class RimInfoTest < Minitest::Test
 
 include FileUtils
 include TestHelper

--- a/test/status_builder_test.rb
+++ b/test/status_builder_test.rb
@@ -8,7 +8,7 @@ require 'rim/git'
 require 'rim/dirty_check'
 require 'rim/status_builder'
 
-class StatusBuilderTest < MiniTest::Test
+class StatusBuilderTest < Minitest::Test
 
 include FileUtils
 include TestHelper


### PR DESCRIPTION
MiniTest namespace which runs test cases changed to Minitest name. As we are using older version test cases where failing to execute. Fixed the namespaces and refactored some code.